### PR TITLE
アップロード前にファイルを先頭に戻すようにしました

### DIFF
--- a/main.go
+++ b/main.go
@@ -575,6 +575,10 @@ func upload(c *webdav.Client, src string, dst string, retry int) error {
 
 		n := 0
 		for {
+			if _, err := f.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+
 			err := uploadFile(c, src, f, stat, path)
 			if err == nil {
 				return nil


### PR DESCRIPTION
#1 の対策です。
アップロード前にファイルを先頭に戻すようにしました。
ビルド方法がすぐに分からなかったので動作確認していないです。