### PR TITLE
Recognize '!' at the beginning of expression

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ Tests
 
 					var files, expressions []string = args, nil
 					for i := range args {
-						if strings.HasPrefix(args[i], "-") || args[i] == "(" {
+						if strings.HasPrefix(args[i], "-") || args[i] == "(" || args[i] == "!" {
 							files, expressions = args[:i], args[i:]
 							break
 						}


### PR DESCRIPTION
式の先頭にある`!`を正しく認識できるようになった。
e.g. `nextcloud-cli find Photos ! -true`