### PR TITLE
Update help for find

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,7 +178,10 @@ Operators
 Tests
 	-name PATTERN	-iname PATTERN	-path PATTERN	-ipath PATTERN
 	-regex PATTERN	-mtime [-+]N	-newer FILE	-newermt YYYY-MM-dd
-	-size [-+]N[kMG]	-empty	-type [fd]	-true	-false`,
+	-size [-+]N[kMG]	-empty	-type [fd]	-true	-false
+
+Actions
+	-quit		-ls		-print		-print0`,
 				Flags: []cli.Flag{
 					&cli.IntFlag{
 						Name:  "maxdepth",


### PR DESCRIPTION
サブコマンド`find`に新しいアクション`-quit, -print, -ls`を追加したため、それに合わせて`nextcloud help find`の内容を更新した。