### PR TITLE
return漏れ修正 Fixes #20

### DIFF
--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -232,6 +232,8 @@ func download(ctx *ctx, src string, dst string) {
 			ctx.setError(err)
 			return
 		}
+
+		return
 	}
 
 	fi, err := ctx.n.Stat(src)


### PR DESCRIPTION
`if ctx.join`に入ったあとに、その中でreturnしていなかったので再度ダウンロードしようとして #20 が起きていた。

Fixes #20﻿
