### PR TITLE
ディレクトリのダウンロード結果の格納パスを修正

### DIFF
--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -243,7 +243,11 @@ func download(ctx *ctx, src string, dst string) {
 	}
 
 	if fi.IsDir() {
-		_downloadDir(ctx, src, dst)
+		if err := os.MkdirAll(filepath.Join(dst, src), fi.Mode()); err != nil {
+			ctx.setError(err)
+			return
+		}
+		_downloadDir(ctx, src, filepath.Join(dst, src))
 		return
 	}
 	if err := _downloadFile(ctx, dst, src, filepath.Join(dst, fi.Name())); err != nil {


### PR DESCRIPTION
Fix #32 
ディレクトリを指定してダウンロードする際、指定した第一階層のディレクトリが作成されず、その中身が出力先ディレクトリに配置される問題を修正。