### PR TITLE
Fix #34

### DIFF
--- a/cmd/upload/upload.go
+++ b/cmd/upload/upload.go
@@ -264,7 +264,7 @@ func upload(ctx *ctx, src string, fi os.FileInfo, dst string) {
 		if _, _, err := getFileInfo(ctx, dst); err == nil {
 			ctx.setError(errors.New("remote file already exists: " + dst))
 			return
-		} else {
+		} else if !os.IsNotExist(errors.Cause(err)) {
 			ctx.setError(
 				errors.Wrap(err, "getFileInfo in handling deconflict failed"),
 			)
@@ -275,7 +275,7 @@ func upload(ctx *ctx, src string, fi os.FileInfo, dst string) {
 		if _, _, err := getFileInfo(ctx, dst); err == nil {
 			fmt.Println("skip already exists file: " + src)
 			return
-		} else if err != nil {
+		} else if !os.IsNotExist(errors.Cause(err)) {
 			ctx.setError(
 				errors.Wrap(err, "getFileInfo in handling deconflict failed"),
 			)
@@ -288,7 +288,7 @@ func upload(ctx *ctx, src string, fi os.FileInfo, dst string) {
 		if _, fis, err := getFileInfo(ctx, dst); err == nil && !fi.ModTime().After(fis[0].ModTime()) {
 			fmt.Println("skip older file: " + src)
 			return
-		} else if err != nil {
+		} else if !os.IsNotExist(errors.Cause(err)) {
 			ctx.setError(
 				errors.Wrap(err, "getFileInfo in handling deconflict failed"),
 			)
@@ -299,7 +299,7 @@ func upload(ctx *ctx, src string, fi os.FileInfo, dst string) {
 		if _, fis, err := getFileInfo(ctx, dst); err == nil && fi.Size() <= getFullSize(ctx, fis) {
 			fmt.Println("skip not larger file: " + src)
 			return
-		} else if err != nil {
+		} else if !os.IsNotExist(errors.Cause(err)) {
 			ctx.setError(
 				errors.Wrap(err, "getFileInfo in handling deconflict failed"),
 			)


### PR DESCRIPTION
**解決されるissue**
fix #34 

**バグの原因**

アップロード処理の前にコンフリクトを調べる際に
- コンフリクトを調べるためのStatでエラーが発生したとき
- コンフリクトが発生していなかった（ファイルが存在しなかった）とき

とが、区別されていませんでした。
具体的には、`upload.go`において、`upload`関数は`getFileInfo`関数が返したエラーが`nil`でなければStatに失敗したとみなしていて、実際にStatでforbiddenなどのエラーが出た場合と、ファイルが存在しなかったのか場合を混同していました。
v1.3.3では、`getFileInfo`関数の返したエラー自体を処理していなかったので動いていました。

**実装内容**
`upload`関数においてコンフリクトを調べる際、`getFileInfo`関数が返したエラーが`IsNotExist`であればそのまま処理を続けられるようにしました。


