### PR TITLE
特定のパスの操作に失敗するバグを修正

### DIFF
--- a/lib/nextcloud/nextcloud.go
+++ b/lib/nextcloud/nextcloud.go
@@ -3,7 +3,6 @@ package nextcloud
 import (
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 
 	"github.com/kurusugawa-computer/nextcloud-cli/lib/webdav"
@@ -24,7 +23,6 @@ type Nextcloud struct {
 }
 
 func (n *Nextcloud) Stat(path string) (os.FileInfo, error) {
-	path = url.PathEscape(path)
 	responses, err := n.w.Propfind(path, webdav.Depth0, propfind)
 	if err != nil {
 		return nil, &os.PathError{Op: "Stat", Path: path, Err: webdavError(err)}
@@ -46,7 +44,6 @@ func (n *Nextcloud) Stat(path string) (os.FileInfo, error) {
 }
 
 func (n *Nextcloud) ReadFile(path string) (io.ReadCloser, error) {
-	path = url.PathEscape(path)
 	body, err := n.w.Get(path)
 	if err != nil {
 		return nil, &os.PathError{Op: "ReadFile", Path: path, Err: webdavError(err)}
@@ -56,7 +53,6 @@ func (n *Nextcloud) ReadFile(path string) (io.ReadCloser, error) {
 }
 
 func (n *Nextcloud) WriteFile(path string, body io.Reader) error {
-	path = url.PathEscape(path)
 	if err := n.w.Put(path, body); err != nil {
 		return &os.PathError{Op: "WriteFile", Path: path, Err: webdavError(err)}
 	}
@@ -65,7 +61,6 @@ func (n *Nextcloud) WriteFile(path string, body io.Reader) error {
 }
 
 func (n *Nextcloud) ReadDir(path string) ([]os.FileInfo, error) {
-	path = url.PathEscape(path)
 	responses, err := n.w.Propfind(path, webdav.Depth1, propfind)
 	if err != nil {
 		return nil, &os.PathError{Op: "ReadDir", Path: path, Err: webdavError(err)}
@@ -88,7 +83,6 @@ func (n *Nextcloud) ReadDir(path string) ([]os.FileInfo, error) {
 }
 
 func (n *Nextcloud) Mkdir(path string) error {
-	path = url.PathEscape(path)
 	if err := n.w.Mkcol(path); err != nil {
 		return &os.PathError{Op: "Mkdir", Path: path, Err: webdavError(err)}
 	}
@@ -135,7 +129,6 @@ func (n *Nextcloud) MkdirAll(path string) error {
 }
 
 func (n *Nextcloud) Delete(path string) error {
-	path = url.PathEscape(path)
 	if err := n.w.Delete(path); err != nil {
 		return &os.PathError{Op: "Delete", Path: path, Err: webdavError(err)}
 	}

--- a/lib/nextcloud/nextcloud.go
+++ b/lib/nextcloud/nextcloud.go
@@ -3,6 +3,7 @@ package nextcloud
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/kurusugawa-computer/nextcloud-cli/lib/webdav"
@@ -23,6 +24,7 @@ type Nextcloud struct {
 }
 
 func (n *Nextcloud) Stat(path string) (os.FileInfo, error) {
+	path = url.PathEscape(path)
 	responses, err := n.w.Propfind(path, webdav.Depth0, propfind)
 	if err != nil {
 		return nil, &os.PathError{Op: "Stat", Path: path, Err: webdavError(err)}
@@ -44,6 +46,7 @@ func (n *Nextcloud) Stat(path string) (os.FileInfo, error) {
 }
 
 func (n *Nextcloud) ReadFile(path string) (io.ReadCloser, error) {
+	path = url.PathEscape(path)
 	body, err := n.w.Get(path)
 	if err != nil {
 		return nil, &os.PathError{Op: "ReadFile", Path: path, Err: webdavError(err)}
@@ -53,6 +56,7 @@ func (n *Nextcloud) ReadFile(path string) (io.ReadCloser, error) {
 }
 
 func (n *Nextcloud) WriteFile(path string, body io.Reader) error {
+	path = url.PathEscape(path)
 	if err := n.w.Put(path, body); err != nil {
 		return &os.PathError{Op: "WriteFile", Path: path, Err: webdavError(err)}
 	}
@@ -61,6 +65,7 @@ func (n *Nextcloud) WriteFile(path string, body io.Reader) error {
 }
 
 func (n *Nextcloud) ReadDir(path string) ([]os.FileInfo, error) {
+	path = url.PathEscape(path)
 	responses, err := n.w.Propfind(path, webdav.Depth1, propfind)
 	if err != nil {
 		return nil, &os.PathError{Op: "ReadDir", Path: path, Err: webdavError(err)}
@@ -83,6 +88,7 @@ func (n *Nextcloud) ReadDir(path string) ([]os.FileInfo, error) {
 }
 
 func (n *Nextcloud) Mkdir(path string) error {
+	path = url.PathEscape(path)
 	if err := n.w.Mkcol(path); err != nil {
 		return &os.PathError{Op: "Mkdir", Path: path, Err: webdavError(err)}
 	}
@@ -129,6 +135,7 @@ func (n *Nextcloud) MkdirAll(path string) error {
 }
 
 func (n *Nextcloud) Delete(path string) error {
+	path = url.PathEscape(path)
 	if err := n.w.Delete(path); err != nil {
 		return &os.PathError{Op: "Delete", Path: path, Err: webdavError(err)}
 	}

--- a/lib/webdav/delete.go
+++ b/lib/webdav/delete.go
@@ -4,19 +4,15 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	_path "path"
-	"strings"
 )
 
 func (n *WebDAV) Delete(path string) error {
-	path = strings.TrimSuffix(n.URL, "/") +
-		"/" +
-		strings.TrimPrefix(_path.Clean(path), "/")
-	req, err := http.NewRequest(http.MethodDelete, path, nil)
+	url := n.mkURL(path)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return &Error{
 			Op:   http.MethodDelete,
-			Path: path,
+			URL:  url,
 			Type: ErrInvalid,
 			Msg:  err.Error(),
 		}
@@ -28,7 +24,7 @@ func (n *WebDAV) Delete(path string) error {
 	if err != nil {
 		return &Error{
 			Op:   http.MethodDelete,
-			Path: path,
+			URL:  url,
 			Type: ErrInvalid,
 			Msg:  err.Error(),
 		}
@@ -45,21 +41,21 @@ func (n *WebDAV) Delete(path string) error {
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return &Error{
 			Op:   http.MethodDelete,
-			Path: path,
+			URL:  url,
 			Type: ErrPermission,
 			Msg:  res.Status,
 		}
 	case http.StatusNotFound:
 		return &Error{
 			Op:   http.MethodDelete,
-			Path: path,
+			URL:  url,
 			Type: ErrNotExist,
 			Msg:  res.Status,
 		}
 	default:
 		return &Error{
 			Op:   http.MethodDelete,
-			Path: path,
+			URL:  url,
 			Type: ErrInvalid,
 			Msg:  res.Status,
 		}

--- a/lib/webdav/error.go
+++ b/lib/webdav/error.go
@@ -10,13 +10,13 @@ const (
 
 type Error struct {
 	Op   string
-	Path string
+	URL  string
 	Type int
 	Msg  string
 }
 
 func (e *Error) Error() string {
-	return e.Op + " " + e.Path + ": " + e.Msg
+	return e.Op + " " + e.URL + ": " + e.Msg
 }
 
 func TypeOf(err error) int {

--- a/lib/webdav/get.go
+++ b/lib/webdav/get.go
@@ -4,15 +4,13 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	_path "path"
-	"strings"
 )
 
 func (n *WebDAV) Get(path string) (io.ReadCloser, error) {
-	path = strings.TrimSuffix(n.URL, "/") + "/" + strings.TrimPrefix(_path.Clean(path), "/")
-	req, err := http.NewRequest(http.MethodGet, path, nil)
+	url := n.mkURL(path)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, &Error{Op: http.MethodGet, Path: path, Type: ErrInvalid, Msg: err.Error()}
+		return nil, &Error{Op: http.MethodGet, URL: url, Type: ErrInvalid, Msg: err.Error()}
 	}
 
 	if n.AuthFunc != nil {
@@ -21,7 +19,7 @@ func (n *WebDAV) Get(path string) (io.ReadCloser, error) {
 
 	resp, err := n.c.Do(req)
 	if err != nil {
-		return nil, &Error{Op: http.MethodGet, Path: path, Type: ErrInvalid, Msg: err.Error()}
+		return nil, &Error{Op: http.MethodGet, URL: url, Type: ErrInvalid, Msg: err.Error()}
 	}
 
 	rc := readCloser{
@@ -40,13 +38,13 @@ func (n *WebDAV) Get(path string) (io.ReadCloser, error) {
 
 	switch resp.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return nil, &Error{Op: http.MethodGet, Path: path, Type: ErrPermission, Msg: resp.Status}
+		return nil, &Error{Op: http.MethodGet, URL: url, Type: ErrPermission, Msg: resp.Status}
 
 	case http.StatusNotFound:
-		return nil, &Error{Op: http.MethodGet, Path: path, Type: ErrNotExist, Msg: resp.Status}
+		return nil, &Error{Op: http.MethodGet, URL: url, Type: ErrNotExist, Msg: resp.Status}
 
 	default:
-		return nil, &Error{Op: http.MethodGet, Path: path, Type: ErrInvalid, Msg: resp.Status}
+		return nil, &Error{Op: http.MethodGet, URL: url, Type: ErrInvalid, Msg: resp.Status}
 	}
 }
 

--- a/lib/webdav/webdav.go
+++ b/lib/webdav/webdav.go
@@ -2,6 +2,9 @@ package webdav
 
 import (
 	"net/http"
+	"net/url"
+	_path "path"
+	"strings"
 )
 
 func New(url string, httpClient *http.Client, authFunc AuthFunc) *WebDAV {
@@ -22,6 +25,10 @@ type WebDAV struct {
 	URL      string
 	AuthFunc AuthFunc
 	c        *http.Client
+}
+
+func (n *WebDAV) mkURL(path string) string {
+	return strings.TrimSuffix(n.URL, "/") + "/" + url.PathEscape(strings.TrimPrefix(_path.Clean(path), "/"))
 }
 
 func BasicAuth(username, password string) AuthFunc {


### PR DESCRIPTION
fix #29

URLとして解釈されるパスに%のようなURLデコードに影響がある文字が含まれていると、URLデコードに失敗してエラーになる。
そのため、事前に必ずURLエンコードすることで正しく解釈できるようにする。