### PR TITLE
Fix #41: downloadコマンドがディレクトリをダウンロードする時の結果のパスを修正

### DIFF
--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -242,12 +242,17 @@ func download(ctx *ctx, src string, dst string) {
 		return
 	}
 
+	base := filepath.Base(src)
+	if src[len(src)-1] == '/' {
+		base = "."
+	}
+
 	if fi.IsDir() {
-		if err := os.MkdirAll(filepath.Join(dst, src), fi.Mode()); err != nil {
+		if err := os.MkdirAll(filepath.Join(dst, base), fi.Mode()); err != nil {
 			ctx.setError(err)
 			return
 		}
-		_downloadDir(ctx, src, filepath.Join(dst, src))
+		_downloadDir(ctx, src, filepath.Join(dst, base))
 		return
 	}
 	if err := _downloadFile(ctx, dst, src, filepath.Join(dst, fi.Name())); err != nil {

--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -242,17 +242,12 @@ func download(ctx *ctx, src string, dst string) {
 		return
 	}
 
-	base := filepath.Base(src)
-	if src[len(src)-1] == '/' {
-		base = "."
-	}
-
 	if fi.IsDir() {
-		if err := os.MkdirAll(filepath.Join(dst, base), fi.Mode()); err != nil {
+		if err := os.MkdirAll(dst, fi.Mode()); err != nil {
 			ctx.setError(err)
 			return
 		}
-		_downloadDir(ctx, src, filepath.Join(dst, base))
+		_downloadDir(ctx, src, dst)
 		return
 	}
 	if err := _downloadFile(ctx, dst, src, filepath.Join(dst, fi.Name())); err != nil {

--- a/main.go
+++ b/main.go
@@ -262,7 +262,8 @@ Actions
 				Name:        "download",
 				Usage:       "Download remote files or directories",
 				Description: "",
-				ArgsUsage:   "FILE [FILE...]",
+				ArgsUsage: `SOURCE [SOURCE...]
+	When you specify a directory, it downloads the files and directories within the directory but not the directory itself.`,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:    "out",


### PR DESCRIPTION
新しく追加されたコードの、出力先パス構築が不適切だった。
修正前は以下のような挙動だった。

```
nextcloud-cli download -o dist dir0/dir1/file001.png
-> dist/file001.png

nextcloud-cli download -o dist dir0/dir1/
-> dist/dir0/dir1/file001.png

nextcloud-cli download -o dist dir0/dir1
-> dist/dir0/dir1/file001.png
```

修正により、以下のような挙動になる。

```
nextcloud-cli download -o dist dir0/dir1/file001.png
-> dist/file001.png

nextcloud-cli download -o dist dir0/dir1/
-> dist/file001.png

nextcloud-cli download -o dist dir0/dir1
-> dist/dir1/file001.png
```