### PR TITLE
update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:18.04 AS devcontainer
-
-RUN set -x \
-    && sed -i.bak -r 's!(deb|deb-src) \S+!\1 mirror://mirrors.ubuntu.com/mirrors.txt!' /etc/apt/sources.list
+FROM ubuntu:22.04 as devcontainer
 
 RUN set -x \
     && apt-get update \
@@ -62,46 +59,8 @@ RUN set -x \
         zip \
     && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
-# docker
-RUN set -x \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg-agent \
-        software-properties-common \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        docker-ce-cli \
-    && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* \
-    && groupadd --gid 999 docker \
-    && usermod -aG docker vscode
-
-# docker compose
-ARG COMPOSE_VERSION=1.27.4
-RUN set -x \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        curl \
-    && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* \
-    && curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
-    && chmod +x /usr/local/bin/docker-compose \
-    && curl -fsSL -o /etc/bash_completion.d/docker-compose "https://raw.githubusercontent.com/docker/compose/${COMPOSE_VERSION}/contrib/completion/bash/docker-compose"
-
-# docker / docker-compose in devcontainer
-RUN set -x \
-    && mkdir -p /usr/local/devcontainer-tool/bin \
-    && curl -fsSL -o /usr/local/devcontainer-tool/bin/docker https://github.com/thamaji/devcontainer-docker/releases/download/v1.0.2/docker \
-    && chmod +x /usr/local/devcontainer-tool/bin/docker \
-    && curl -fsSL -o /usr/local/devcontainer-tool/bin/docker-compose https://github.com/thamaji/devcontainer-compose/releases/download/v1.0.3/docker-compose \
-    && chmod +x /usr/local/devcontainer-tool/bin/docker-compose
-ENV PATH=/usr/local/devcontainer-tool/bin:${PATH}
-
 # golang
-ARG GO_VERSION=1.16.5
+ARG GO_VERSION=1.21.3
 RUN set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -109,13 +68,12 @@ RUN set -x \
         curl \
     && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* \
     && curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/local
+
 ENV GOROOT=/usr/local/go \
     GOPATH=/home/vscode/go \
     PATH=/home/vscode/go/bin:/usr/local/go/bin:${PATH}
 
 USER vscode
-
-RUN go env -w GOPRIVATE=github.com/kurusugawa-computer
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "bash", "-eux", "/entrypoint.sh" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,18 +6,15 @@
 		"dockerfile": "Dockerfile",
 		"context": ".",
 		"args": {
-			"COMPOSE_VERSION": "1.27.4",
-			"GO_VERSION": "1.16.5"
+			"GO_VERSION": "1.21.3"
 		},
 		"target": "devcontainer"
 	},
-	"postCreateCommand": "go install github.com/kurusugawa-computer/kciguild-gokci/gokci/cmd/gokci@latest",
 	"remoteUser": "vscode",
 	"containerUser": "vscode",
 	"updateRemoteUserUID": true,
 	"overrideCommand": false,
 	"mounts": [
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
 		"source=${localWorkspaceFolder}/.devcontainer/.extensions,target=/home/vscode/.vscode-server/extensions,type=bind",
 		"source=${localWorkspaceFolder}/.devcontainer/.go,target=/home/vscode/go,type=bind"
 	],
@@ -25,11 +22,21 @@
 		"--init",
 		"--net=host",
 	],
-	"extensions": [
-		"766b.go-outliner",
-		"golang.go",
-		"jgclark.vscode-todo-highlight",
-		"liuchao.go-struct-tag",
-		"streetsidesoftware.code-spell-checker"
-	]
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"766b.go-outliner",
+				"golang.go",
+				"jgclark.vscode-todo-highlight",
+				"liuchao.go-struct-tag",
+				"streetsidesoftware.code-spell-checker"
+			],
+		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker": {
+			"version": "latest",
+			"dockerDashComposeVersion": "v2"
+		}
+	}
 }


### PR DESCRIPTION
ubuntu 18.04 -> 22.04
docker in dockerをdevcontainer側の機能で実現するように変更
go 1.16.5 -> 1.21.3
使われていないのでgokciを削除

`release.sh`が正常に動くことは確認済みです