### PR TITLE
User-Agentにツールの情報を追加

### DIFF
--- a/lib/webdav/webdav.go
+++ b/lib/webdav/webdav.go
@@ -1,6 +1,7 @@
 package webdav
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	_path "path"
@@ -31,9 +32,12 @@ func (n *WebDAV) mkURL(path string) string {
 	return strings.TrimSuffix(n.URL, "/") + "/" + url.PathEscape(strings.TrimPrefix(_path.Clean(path), "/"))
 }
 
-func BasicAuth(username, password string) AuthFunc {
+func BasicAuth(username, password, appname, version string) AuthFunc {
 	return func(r *http.Request) {
 		r.SetBasicAuth(username, password)
+
+		userAgent := fmt.Sprintf("%s/%s", appname, version)
+		r.Header.Set("User-Agent", userAgent)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 )
 
 var appname = "nextcloud-cli"
+var version = "v2.1.0"
 
 func main() {
 	numCPU := runtime.NumCPU()
@@ -45,7 +46,7 @@ func main() {
 		Name:                  appname,
 		Usage:                 "NextCloud CLI",
 		ArgsUsage:             " ",
-		Version:               "v2.1.0",
+		Version:               version,
 		Flags:                 []cli.Flag{},
 		EnableShellCompletion: true,
 		Commands: []*cli.Command{
@@ -114,7 +115,7 @@ func main() {
 						Password: credentials.Password(password),
 					}
 
-					auth := webdav.BasicAuth(credential.Username, credential.Password.String())
+					auth := webdav.BasicAuth(credential.Username, credential.Password.String(), appname, version)
 					nextcloud := nextcloud.New(credential.URL, httpClient(), auth)
 
 					if _, err := nextcloud.Stat("/"); err != nil {
@@ -155,7 +156,7 @@ func main() {
 						return errors.New("you need to login")
 					}
 
-					auth := webdav.BasicAuth(credential.Username, credential.Password.String())
+					auth := webdav.BasicAuth(credential.Username, credential.Password.String(), appname, version)
 					nextcloud := nextcloud.New(credential.URL, httpClient(), auth)
 
 					args := ctx.Args().Slice()
@@ -203,7 +204,7 @@ Actions
 						return errors.New("you need to login")
 					}
 
-					auth := webdav.BasicAuth(credential.Username, credential.Password.String())
+					auth := webdav.BasicAuth(credential.Username, credential.Password.String(), appname, version)
 					nextcloud := nextcloud.New(credential.URL, httpClient(), auth)
 
 					args := ctx.Args().Slice()
@@ -250,7 +251,7 @@ Actions
 						return errors.New("you need to login")
 					}
 
-					auth := webdav.BasicAuth(credential.Username, credential.Password.String())
+					auth := webdav.BasicAuth(credential.Username, credential.Password.String(), appname, version)
 					nextcloud := nextcloud.New(credential.URL, httpClient(), auth)
 
 					opts := []open.Option{
@@ -308,7 +309,7 @@ Actions
 						return errors.New("you need to login")
 					}
 
-					auth := webdav.BasicAuth(credential.Username, credential.Password.String())
+					auth := webdav.BasicAuth(credential.Username, credential.Password.String(), appname, version)
 					nextcloud := nextcloud.New(credential.URL, httpClient(), auth)
 
 					opts := []download.Option{
@@ -358,7 +359,7 @@ Actions
 						return errors.New("you need to login")
 					}
 
-					auth := webdav.BasicAuth(credential.Username, credential.Password.String())
+					auth := webdav.BasicAuth(credential.Username, credential.Password.String(), appname, version)
 					nextcloud := nextcloud.New(credential.URL, httpClient(), auth)
 
 					opts := []get.Option{
@@ -418,7 +419,7 @@ Actions
 						return errors.New("you need to login")
 					}
 
-					auth := webdav.BasicAuth(credential.Username, credential.Password.String())
+					auth := webdav.BasicAuth(credential.Username, credential.Password.String(), appname, version)
 					nextcloud := nextcloud.New(credential.URL, httpClient(), auth)
 
 					opts := []upload.Option{
@@ -472,7 +473,7 @@ Actions
 						return errors.New("you need to login")
 					}
 
-					auth := webdav.BasicAuth(credential.Username, credential.Password.String())
+					auth := webdav.BasicAuth(credential.Username, credential.Password.String(), appname, version)
 					nextcloud := nextcloud.New(credential.URL, httpClient(), auth)
 
 					opts := []rm.Option{


### PR DESCRIPTION
close #49 

`User-Agent`を`Go-http-client/1.1`から`appname/version`に変更しました。

再現方法：
最小
1. [Slackメッセージ](https://kurusugawajp.slack.com/archives/C03UMCRCUJG/p1720184146677609)のようなUser-Agentを確認できるサーバーを立てる。
2. release.shを用いてビルドする。
3. loginコマンドを1.サーバーのURLを用いて実行する。

任意のコマンドで確認
1. [Slackメッセージ](https://kurusugawajp.slack.com/archives/C03UMCRCUJG/p1720184146677609)のようなUser-Agentを確認できるサーバーを立てる。
2. コードを書き換え`credentials.URL`を立てたサーバーのURLに変更する。 
3. `release.sh`を用いてビルドする。
4. 任意のコマンドを実行する。
