### PR TITLE
uploadのdeconflictのロジックを修正

### DIFF
--- a/cmd/upload/upload.go
+++ b/cmd/upload/upload.go
@@ -336,10 +336,12 @@ func upload(ctx *ctx, src string, fi os.FileInfo, dst string, igs []ignPtn) {
 	case 2: // DeconflictOverwrite
 
 	case 3: // DeconflictNewest
-		if _, fis, err := getFileInfo(ctx, dst); err == nil && !fi.ModTime().After(fis[0].ModTime()) {
-			fmt.Println("skip older file: " + src)
-			return
-		} else if err != nil && !errors.Is(errors.Cause(err), fs.ErrNotExist) {
+		if _, fis, err := getFileInfo(ctx, dst); err == nil {
+			if !fi.ModTime().After(fis[0].ModTime()) {
+				fmt.Println("skip older file: " + src)
+				return
+			}
+		} else if !errors.Is(errors.Cause(err), fs.ErrNotExist) {
 			ctx.setError(
 				errors.Wrap(err, "getFileInfo in handling deconflict failed"),
 			)
@@ -347,10 +349,12 @@ func upload(ctx *ctx, src string, fi os.FileInfo, dst string, igs []ignPtn) {
 		}
 
 	case 4: // DeconflictLarger
-		if _, fis, err := getFileInfo(ctx, dst); err == nil && fi.Size() <= getFullSize(ctx, fis) {
-			fmt.Println("skip not larger file: " + src)
-			return
-		} else if err != nil && !errors.Is(errors.Cause(err), fs.ErrNotExist) {
+		if _, fis, err := getFileInfo(ctx, dst); err == nil {
+			if fi.Size() <= getFullSize(ctx, fis) {
+				fmt.Println("skip not larger file: " + src)
+				return
+			}
+		} else if !errors.Is(errors.Cause(err), fs.ErrNotExist) {
 			ctx.setError(
 				errors.Wrap(err, "getFileInfo in handling deconflict failed"),
 			)

--- a/cmd/upload/upload.go
+++ b/cmd/upload/upload.go
@@ -339,7 +339,7 @@ func upload(ctx *ctx, src string, fi os.FileInfo, dst string, igs []ignPtn) {
 		if _, fis, err := getFileInfo(ctx, dst); err == nil && !fi.ModTime().After(fis[0].ModTime()) {
 			fmt.Println("skip older file: " + src)
 			return
-		} else if !errors.Is(errors.Cause(err), fs.ErrNotExist) {
+		} else if err != nil && !errors.Is(errors.Cause(err), fs.ErrNotExist) {
 			ctx.setError(
 				errors.Wrap(err, "getFileInfo in handling deconflict failed"),
 			)
@@ -350,7 +350,7 @@ func upload(ctx *ctx, src string, fi os.FileInfo, dst string, igs []ignPtn) {
 		if _, fis, err := getFileInfo(ctx, dst); err == nil && fi.Size() <= getFullSize(ctx, fis) {
 			fmt.Println("skip not larger file: " + src)
 			return
-		} else if !errors.Is(errors.Cause(err), fs.ErrNotExist) {
+		} else if err != nil && !errors.Is(errors.Cause(err), fs.ErrNotExist) {
 			ctx.setError(
 				errors.Wrap(err, "getFileInfo in handling deconflict failed"),
 			)


### PR DESCRIPTION
## 解決した問題
`upload`コマンドを`--deconflict newest`(または`--deconflict larger`) で実行し、アップロード対象ファイルが既にnextcloud上に存在しているファイルよりも新しい（またはサイズが大きい）場合に上書きされるはずがされない。

## 原因
アップロード対象ファイルが既にnextcloud上に存在しているケースの条件分岐が間違っていた。

## 確認手順
（以下の手順の前に修正したコードでビルドしバイナリを作り、ログインしておく）
1. foo.txtをアップロード　`nextcloud-cli upload foo.txt`
2. foo.txtに変更を加える（タイムスタンプを新しくする/ファイルサイズを大きくする）
3. foo.txtをアップロードし、正しく上書きされているか確認する　`nextcloud-cli upload  --deconflict newest(またはlarger) foo.txt`
